### PR TITLE
Feature/no stack traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This retrieves the README and test suite for your current assignment.
 
 This submits `example.rb` on your current assignment.
 
+    $ export EXERCISM_ENV=development
+
+Reveals stack traces on errors.
+
 ## Contributing
 
 1. Fork it

--- a/bin/exercism
+++ b/bin/exercism
@@ -1,7 +1,12 @@
 #!/usr/bin/env ruby
 
-trap("INT") { print "\nExiting \n"; exit }
+trap("INT") { print "\nExiting. \n"; exit }
 $:.unshift File.expand_path("../../lib", __FILE__)
 require 'cli'
 
-Exercism::CLI.start
+begin
+  Exercism::CLI.start
+rescue Exception => e
+  print "\nERROR: Something went wrong. Exiting.\n"
+  raise e if ENV['EXERCISM_ENV'] =~ /test|development/
+end

--- a/bin/exercism
+++ b/bin/exercism
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+trap("INT") { print "\nExiting \n"; exit }
 $:.unshift File.expand_path("../../lib", __FILE__)
 require 'cli'
 


### PR DESCRIPTION
I'm a bit of a nut when it comes to hiding stack traces from end users. Many in the Ruby community think I'm nuts so no hard feelings if this doesn't get merged in. :)
-  Capture SIGINT to prevent stack traces being shown to the user on intentional exiting.
-  A big nasty begin rescue block to wrap the whole application to prevent stack traces being shown to the user on unintentional exiting. 
- Override the rescue Exception for development mode.
