### PR TITLE
DRY up require statements in Exercism::CLI.

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -2,11 +2,10 @@ require 'thor'
 
 class Exercism
   class CLI < Thor
+    require 'exercism'
 
     desc "version", "Output current version of gem"
     def version
-      require 'exercism'
-
       puts Exercism::VERSION
     end
 
@@ -15,8 +14,6 @@ class Exercism
     desc "fetch", "Fetch current assignment from exercism.io"
     method_option :host, aliases: '-h', default: 'http://exercism.io', desc: 'the url of the exercism application'
     def fetch
-      require 'exercism'
-
       api = Exercism::Api.new(options[:host], Exercism.user, Exercism.project_dir)
       assignments = api.fetch
       if assignments.empty?
@@ -31,8 +28,6 @@ class Exercism
     desc "peek", "Fetch upcoming assignment from exercism.io"
     method_option :host, aliases: '-h', default: 'http://exercism.io', desc: 'the url of the exercism application'
     def peek
-      require 'exercism'
-
       api = Exercism::Api.new(options[:host], Exercism.user, Exercism.project_dir)
       assignments = api.peek
       if assignments.empty?
@@ -47,8 +42,6 @@ class Exercism
     desc "submit FILE", "Submit code to exercism.io on your current assignment"
     method_option :host, aliases: '-h', default: 'http://exercism.io', desc: 'the url of the exercism application'
     def submit(file)
-      require 'exercism'
-
       path = File.join(FileUtils.pwd, file)
       begin
         Exercism::Api.new(options[:host], Exercism.user).submit(file)
@@ -62,8 +55,6 @@ class Exercism
 
     desc "login", "Save exercism.io api credentials"
     def login
-      require 'exercism'
-
       username = ask("Your GitHub username:")
       key = ask("Your exercism.io API key:")
       default_path = FileUtils.pwd
@@ -79,15 +70,11 @@ class Exercism
 
     desc "logout", "Clear exercism.io api credentials"
     def logout
-      require 'exercism'
-
       Exercism.config.delete
     end
 
     desc "whoami", "Get the github username that you are logged in as"
     def whoami
-      require 'exercism'
-
       puts Exercism.user.github_username
     rescue Errno::ENOENT
       puts "You are not logged in."


### PR DESCRIPTION
I wonder why `require 'exercism'` has been used in every method?
