### PR TITLE
Extract method to DRY up API creation knowledge

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -17,7 +17,6 @@ class Exercism
     def fetch
       require 'exercism'
 
-      api = Exercism::Api.new(options[:host], Exercism.user, Exercism.project_dir)
       assignments = api.fetch
       report(assignments)
     end
@@ -27,7 +26,6 @@ class Exercism
     def peek
       require 'exercism'
 
-      api = Exercism::Api.new(options[:host], Exercism.user, Exercism.project_dir)
       assignments = api.peek
       report(assignments)
     end
@@ -83,6 +81,10 @@ class Exercism
     end
 
 private
+    def api(host = options[:host])
+      Exercism::Api.new(host, Exercism.user, Exercism.project_dir)
+    end
+
     def submission_url(response_body, host)
       body = JSON.parse(response_body)
       "#{host}/user/#{body['language']}/#{body['exercise']}" 


### PR DESCRIPTION
Last one of these mini pull requests of me chasing the 4.0 from Code Climate - I promise! This should clear the last warning from Code Climate by extracting out the creation of the API object in the CLI into its own method.
