### PR TITLE
Adds the option for storing config somewhere else issue #19

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -74,6 +74,13 @@ class Exercism
         path = default_path
       end
       path = File.expand_path(path)
+
+      puts "Where do you want your configuration stored?"
+      puts "1. #{Exercism.home} (default)"
+      puts "2. #{Exercism.alternate_config_path}"
+
+      which = ask(" ")
+      Exercism.home = Exercism.alternate_config_path if which.to_i == 2
       Exercism.login(username, key, path)
 
       say("Your credentials have been written to #{Exercism.config.file}")

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -75,7 +75,7 @@ class Exercism
       end
       path = File.expand_path(path)
 
-      puts "Where do you want your configuration stored?"
+      puts "Where do you want your configuration stored? (type a number)"
       puts "1. #{Exercism.home} (default)"
       puts "2. #{Exercism.alternate_config_path}"
 

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -4,6 +4,7 @@ require 'yaml'
 require 'fileutils'
 require 'faraday'
 require 'exercism/version'
+require 'exercism/env'
 require 'exercism/config'
 require 'exercism/user'
 require 'exercism/assignment'
@@ -11,12 +12,12 @@ require 'exercism/api'
 
 class Exercism
 
+  class << self
+    attr_writer :home
+  end
+
   def self.home
-    if ENV["OS"] == 'Windows_NT' then
-      ENV["HOMEDRIVE"]+ENV["HOMEPATH"]
-    else
-      Dir.home(Etc.getlogin)
-    end
+    @home ||= Env.home
   end
 
   def self.login(github_username, key, dir)
@@ -42,4 +43,7 @@ class Exercism
     config.project_dir
   end
 
+  def self.alternate_config_path
+    Config.alternate_path
+  end
 end

--- a/lib/exercism/config.rb
+++ b/lib/exercism/config.rb
@@ -1,8 +1,9 @@
 class Exercism
   class Config
+    FILE = 'exercism'
 
     def self.alternate_path
-      File.join(Env.home, '.config', 'exercism')
+      File.join(Env.home, '.config')
     end
 
     def self.read(path)
@@ -24,11 +25,7 @@ class Exercism
 
     def initialize(path)
       @path = path
-      @file = File.join(path, '.exercism')
-    end
-
-    def exists?
-      File.exists?(@file)
+      set_file      
     end
 
     def github_username
@@ -59,10 +56,23 @@ class Exercism
     end
 
     def delete
-      FileUtils.rm(file) if File.exists?(file)
+      FileUtils.rm(file) if exists?
+    end
+
+    def exists?
+      File.exists?(@file)
     end
 
     private
+    
+    def set_file
+      filename = ('.' if is_default?) + FILE
+      @file = File.join(@path, filename)
+    end
+
+    def is_default?
+      @path != /\.config/
+    end
 
     def from_yaml
       unless @data

--- a/lib/exercism/config.rb
+++ b/lib/exercism/config.rb
@@ -1,8 +1,14 @@
 class Exercism
   class Config
 
+    def self.alternate_path
+      File.join(Env.home, '.config', 'exercism')
+    end
+
     def self.read(path)
-      new(path)
+      config = new(path)
+      config = new(alternate_path) unless config.exists?
+      config
     end
 
     def self.write(path, data)
@@ -13,11 +19,16 @@ class Exercism
       config.save
     end
 
-    attr_reader :file
+    attr_reader :file, :path
     attr_writer :github_username, :key, :project_dir
 
     def initialize(path)
+      @path = path
       @file = File.join(path, '.exercism')
+    end
+
+    def exists?
+      File.exists?(@file)
     end
 
     def github_username
@@ -34,6 +45,8 @@ class Exercism
 
     def save
       FileUtils.mkdir_p(project_dir)
+      FileUtils.mkdir_p(path)
+
       File.open file, 'w' do |f|
         data = {
           'github_username' => github_username,

--- a/lib/exercism/env.rb
+++ b/lib/exercism/env.rb
@@ -1,0 +1,11 @@
+class Exercism
+  class Env
+    def self.home
+      if ENV["OS"] == 'Windows_NT' then
+        ENV["HOMEDRIVE"]+ENV["HOMEPATH"]
+      else
+        Dir.home(Etc.getlogin)
+      end
+    end
+  end
+end

--- a/test/exercism/config_test.rb
+++ b/test/exercism/config_test.rb
@@ -6,13 +6,29 @@ class ConfigTest < Minitest::Test
     './test/fixtures'
   end
 
+  def data
+    { 
+      'github_username' => 'bob', 
+      'key' => '7a7096c',
+      'project_dir' => '/tmp'
+    }
+  end
+
   def key
-    '7a7096c'
+    data['key']
+  end
+
+  def write_config_file(path, info = {})
+    Exercism::Config.write(path, data.merge!(info))
   end
 
   def teardown
     if File.exists?('./test/fixtures/.exercism')
       FileUtils.rm('./test/fixtures/.exercism')
+    end
+
+    if File.exists?('./test/fixtures/.config/exercism/.exercism')
+      FileUtils.rm_r('./test/fixtures/.config')
     end
 
     if File.exists?('./test/fixtures/some/project/dir')
@@ -27,39 +43,34 @@ class ConfigTest < Minitest::Test
     assert_equal '/tmp', config.project_dir
   end
 
+  def test_reads_from_alternate_path_config_file_when_in_default_path_is_missing
+    write_config_file('./test/fixtures/.config/exercism')
+    Exercism::Config.stub(:alternate_path, './test/fixtures/.config/exercism') do
+      config = Exercism::Config.read('./test/fixtures/some/path/with/no/config/file')
+      assert_equal 'bob', config.github_username
+      assert_equal key, config.key
+      assert_equal '/tmp', config.project_dir  
+    end
+  end
+
   def test_write_config_file
-    data = {
-      'github_username' => 'bob',
-      'key' => key,
-      'project_dir' => '/tmp'
-    }
-    config = Exercism::Config.write(path, data)
+    config = write_config_file(path)
     assert_equal 'bob', config.github_username
     assert_equal key, config.key
     assert_equal '/tmp', config.project_dir
   end
 
   def test_delete_config_file
-    data = {
-      'github_username' => 'bob',
-      'key' => key,
-      'project_dir' => '/tmp'
-    }
-    config = Exercism::Config.write(path, data)
+    config = write_config_file(path)
     filename = config.file
     config.delete
     assert !File.exists?(filename)
   end
 
   def test_write_directory_if_missing
-    project_dir = './test/fixtures/some/project/dir'
-    data = {
-      'github_username' => 'bob',
-      'key' => key,
-      'project_dir' => project_dir
-    }
-    Exercism::Config.write(path, data)
-    assert File.exist? project_dir
+    data = {'project_dir' => './test/fixtures/some/project/dir'}
+    write_config_file(path, data)
+    assert File.exist?(data['project_dir'])
   end
 
 end

--- a/test/exercism/config_test.rb
+++ b/test/exercism/config_test.rb
@@ -27,7 +27,7 @@ class ConfigTest < Minitest::Test
       FileUtils.rm('./test/fixtures/.exercism')
     end
 
-    if File.exists?('./test/fixtures/.config/exercism/.exercism')
+    if File.exists?('./test/fixtures/.config/exercism')
       FileUtils.rm_r('./test/fixtures/.config')
     end
 
@@ -43,10 +43,10 @@ class ConfigTest < Minitest::Test
     assert_equal '/tmp', config.project_dir
   end
 
-  def test_reads_from_alternate_path_config_file_when_in_default_path_is_missing
-    write_config_file('./test/fixtures/.config/exercism')
-    Exercism::Config.stub(:alternate_path, './test/fixtures/.config/exercism') do
-      config = Exercism::Config.read('./test/fixtures/some/path/with/no/config/file')
+  def test_reads_from_alternate_path_config_file_when_config_file_in_default_path_is_missing
+    write_config_file('./test/fixtures/.config')
+    Exercism::Config.stub(:alternate_path, './test/fixtures/.config') do
+      config = Exercism::Config.read(path)
       assert_equal 'bob', config.github_username
       assert_equal key, config.key
       assert_equal '/tmp', config.project_dir  


### PR DESCRIPTION
Tries to add the feature asked in issue #19. Currently not sure how to name the .exercism file and it was left as-is. The user can choose to store configuration in ~/.exercism or ~/.config/exercism/.exercism.

The path ~/.config/exercism seems appropiate perhaps for storing other information pertinent to exorcism.
