### PR TITLE
Remove period after feedback message

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -55,7 +55,7 @@ class Exercism
         response = Exercism::Api.new(options[:host], Exercism.user).submit(file)
         puts "Your assignment has been submitted."
         url = submission_url(response.body, options[:host])
-        puts "For feedback on your submission visit #{url}."
+        puts "For feedback on your submission visit #{url}"
       rescue Exception => e
         puts "There was an issue with your submission."
         puts e.message


### PR DESCRIPTION
it's grammatically wrong, but when people copy/paste, they add the `.`, which is worse.
