### PR TITLE
Silence Faraday warning, Json missing gem on Ruby 1.8.7, and confirm before submission feature

### DIFF
--- a/exercism.gemspec
+++ b/exercism.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "json" 
   spec.add_dependency "faraday"
   spec.add_dependency "thor"
   spec.add_development_dependency "bundler", "~> 1.3"
@@ -28,7 +29,6 @@ Gem::Specification.new do |spec|
 
 
   if RUBY_VERSION <= "1.8.7"
-    spec.add_dependency "json"
     spec.add_development_dependency "nokogiri", "~>1.5.0"
   else
     spec.add_development_dependency "nokogiri", "~>1.6.0"

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -60,7 +60,7 @@ class Exercism
       rescue Exception => e
         puts "There was an issue with your submission."
         puts e.message
-      end
+      end if confirms_submission?
     end
 
     desc "login", "Save exercism.io api credentials"
@@ -114,6 +114,11 @@ private
           puts "Fetched #{File.join(assignment.assignment_dir)}"
         end
       end
+    end
+
+    def confirms_submission?
+      confirm = ask("Are you SURE you want to submit? (anything other than 'y' or 'yes' will cancel)")
+      confirm == 'y' || confirm == 'yes'
     end
 
   end

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -1,5 +1,14 @@
 require 'etc'
-require 'json'
+
+require 'json' if RUBY_VERSION == '1.8.7'
+ 
+old_warn, $-w = $-w, nil
+begin
+  require 'faraday'
+ensure
+  $-w = old_warn
+end
+
 require 'yaml'
 require 'fileutils'
 require 'faraday'


### PR DESCRIPTION
1. Ruby version conditionals seem not to work in the .gemspec
2. spec.add_dependency "json" was left without the conditional
   (but in later Ruby versions it comes built-in) can someone test this in their machine?
3. Silences Faraday warning on Ruby 1.8
   When you run exercism on Ruby 1.8.7 faraday always gives the warning 
   >  Faraday: you may want to install system_timer for reliable timeouts
4. Adds the feature in issue #30
