### PR TITLE
Silences Faraday warning on Ruby 1.8

### DIFF
--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -2,7 +2,14 @@ require 'etc'
 require 'json'
 require 'yaml'
 require 'fileutils'
-require 'faraday'
+
+old_warn, $-w = $-w, nil
+begin
+  require 'faraday'
+ensure
+  $-w = old_warn
+end
+
 require 'exercism/version'
 require 'exercism/config'
 require 'exercism/user'


### PR DESCRIPTION
When you run exercism on Ruby 1.8.7 faraday always gives the warning 
  Faraday: you may want to install system_timer for reliable timeouts

This pull requests silences it.
