### PR TITLE
Refactor `CLI.login` in the spirit of convention over configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .approvals
+tags

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This submits `example.rb` on your current assignment.
 
 Reveals stack traces on errors.
 
+By default, Exercism will create a config file in the base of your home directory, i.e. `~/.exercism`. This file can be moved to `~/.config/exercism` if desired.
+
 ## Contributing
 
 1. Fork it

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -77,26 +77,7 @@ class Exercism
     def login
       require 'exercism'
 
-      username = ask("Your GitHub username:")
-      key = ask("Your exercism.io API key:")
-      default_dir = FileUtils.pwd
-      say "What is your exercism exercises project path?"
-      say "Press Enter to select the default (#{default_dir}):\n"
-      dir = ask ">"
-      if dir.empty?
-        dir = default_dir
-      end
-      project_dir = File.expand_path(dir)
-
-      say "Where do you want your configuration stored? (type a number)"
-      say "1. #{File.join(Exercism.home, '.exercism')}"
-      say "2. #{File.join(Exercism.home, '.config', 'exercism')}"
-
-      if ask(">").to_i == 2
-        Exercism.login username, key, project_dir, File.join(Exercism.home, '.config')
-      else
-        Exercism.login username, key, project_dir, Exercism.home
-      end
+      Exercism.login username, key, project_dir
 
       say("Your credentials have been written to #{Exercism.config.file}")
     end
@@ -118,6 +99,22 @@ class Exercism
     end
 
     private
+
+    def username
+      ask("Your GitHub username:")
+    end
+
+    def key
+      ask("Your exercism.io API key:")
+    end
+
+    def project_dir
+      default_dir = FileUtils.pwd
+      say "What is your exercism exercises project path?"
+      say "Press Enter to select the default (#{default_dir}):\n"
+      dir = ask ">", :default => default_dir
+      File.expand_path(dir)
+    end
 
     def api(host = options[:host])
       Exercism::Api.new(host, Exercism.user, Exercism.project_dir)

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -25,13 +25,13 @@ class Exercism
     @home ||= Env.home
   end
 
-  def self.login(github_username, key, dir, config_path)
+  def self.login(github_username, key, dir)
     data = {
       'github_username' => github_username,
       'key' => key,
       'project_dir' => dir
     }
-    Config.write(config_path, data)
+    Config.write home, data
   end
 
   def self.user

--- a/lib/exercism/config.rb
+++ b/lib/exercism/config.rb
@@ -7,9 +7,7 @@ class Exercism
 
     def self.read(path)
       config = new(path)
-      return config if config.exists?
-
-      new(alternate_path) unless config.exists?
+      config.exists? ? config : new(alternate_path)
     end
 
     def self.write(path, data)

--- a/test/exercism_test.rb
+++ b/test/exercism_test.rb
@@ -21,7 +21,7 @@ class ExercismTest < Minitest::Test
     home = './test/fixtures'
     Exercism.stub(:home, home) do
       key = '97e9975'
-      Exercism.login('bob', key, '/tmp', home)
+      Exercism.login('bob', key, '/tmp')
       user = Exercism.user
       assert_equal 'bob', user.github_username
       assert_equal key, user.key


### PR DESCRIPTION
With wonderful help from @zph and the work of @androbtech and the Exercism team, this pull request contains changes that allow the usage of `~/.config/exercism` without impinging on default use or confusing new users with too many choices.
