### PR TITLE
Ruby v1.9.1 does not have Dir.home, so we need a fallback

### DIFF
--- a/lib/exercism/env.rb
+++ b/lib/exercism/env.rb
@@ -3,7 +3,7 @@ class Exercism
     def self.home
       if windows_nt?
         ENV["HOMEDRIVE"] + ENV["HOMEPATH"]
-      elsif ruby18?
+      elsif ruby18? || ruby191?
         File.expand_path('~')
       else
         Dir.home(Etc.getlogin)
@@ -16,6 +16,10 @@ class Exercism
 
     def self.ruby18?
       RUBY_VERSION == '1.8.7'
+    end
+    
+    def self.ruby191?
+      RUBY_VERSION == '1.9.1'  
     end
   end
 end


### PR DESCRIPTION
On ruby 1.9.1, the login method errors out with "NoMethodError: undefined method `home' for Dir:Class", since Dir.home was not introduced until ruby 1.9.2
