### PR TITLE
Load the Faraday adapter.

### DIFF
--- a/lib/exercism/api.rb
+++ b/lib/exercism/api.rb
@@ -1,3 +1,5 @@
+require 'faraday/adapter/net_http'
+
 class Exercism
   class Api
 


### PR DESCRIPTION
This adds support for Faraday 0.9.x series, which don't automatically load all of its adapters.

before:

```
$ EXERCISM_ENV=test exercism fetch

ERROR: Something went wrong. Exiting.
uninitialized constant Faraday::Adapter::NetHttp

/Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/exercism-0.0.20/lib/exercism/api.rb:13:in `block in conn': uninitialized constant Faraday::Adapter::NetHttp (NameError)
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/faraday-0.9.0.rc5/lib/faraday/connection.rb:84:in `initialize'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/faraday-0.9.0.rc5/lib/faraday.rb:70:in `new'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/faraday-0.9.0.rc5/lib/faraday.rb:70:in `new'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/exercism-0.0.20/lib/exercism/api.rb:12:in `conn'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/exercism-0.0.20/lib/exercism/api.rb:45:in `get_and_save'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/exercism-0.0.20/lib/exercism/api.rb:23:in `fetch'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/exercism-0.0.20/lib/cli.rb:36:in `fetch'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/exercism-0.0.20/bin/exercism:8:in `<top (required)>'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/bin/exercism:23:in `load'
    from /Users/yaauie/.rbenv/versions/1.9.3-p194/bin/exercism:23:in `<main>'
```

after:

```
$ EXERCISM_ENV=test exercism fetch
No assignments fetched.
```
