### PR TITLE
Switch to WebMock for future proofing

### DIFF
--- a/exercism.gemspec
+++ b/exercism.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "minitest", '~> 5.0'
   spec.add_development_dependency "vcr", '~> 2.4'
-  spec.add_development_dependency "fakeweb"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "rake"
 
 

--- a/test/exercism/api_test.rb
+++ b/test/exercism/api_test.rb
@@ -6,7 +6,7 @@ test_dir = File.join(FileUtils.pwd, 'test/fixtures')
 
 VCR.configure do |c|
   c.cassette_library_dir = File.join(test_dir, 'vcr_cassettes')
-  c.hook_into :fakeweb
+  c.hook_into :webmock
 end
 
 require 'approvals'


### PR DESCRIPTION
Since FakeWeb is aparently deprecated for VCR 3.0 and beyond, switch to WebMock for future proofing.
