### PR TITLE
Adds Clojure, Python and Go extensions to `test_identifiers`

### DIFF
--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -20,7 +20,10 @@ class Exercism
       {
         :ruby => '_test.rb',
         :js => '.spec.js',
-        :elixir => '_test.exs'
+        :elixir => '_test.exs',
+        :clojure => '_test.clj',
+        :python => '_test.py',
+        :go => '_test.go',
       }
     end
 

--- a/test/exercism/submission_test.rb
+++ b/test/exercism/submission_test.rb
@@ -25,4 +25,28 @@ class SubmissionTest < Minitest::Test
   def test_identifies_javascript_tests
     assert Exercism::Submission.test?('queens.spec.js')
   end
+
+  def test_knows_clojure_code
+    refute Exercism::Submission.test?('queens.clj')
+  end
+
+  def test_identifies_clojure_tests
+    assert Exercism::Submission.test?('queens_test.clj')
+  end
+
+  def test_knows_python_code
+    refute Exercism::Submission.test?('queens.py')
+  end
+
+  def test_identifies_python_tests
+    assert Exercism::Submission.test?('queens_test.py')
+  end
+
+  def test_knows_go_code
+    refute Exercism::Submission.test?('queens.go')
+  end
+
+  def test_identifies_go_tests
+    assert Exercism::Submission.test?('queens_test.go')
+  end
 end


### PR DESCRIPTION
The `test_indentifiers` method has fallen out of step with the site and is missing entries for Clojure and Python. As it looks like Go has the most assignments created out of the non-published languages, I've added an entry and associated test for it as well.

I had an initial thought with regard to improving the maintainability of the `submission` test file: as the file formats for test files are common to all languages excepting JavaScript, it might be worth creating the test methods dynamically based on a hash mapping of language to file extensions. I'll have a go at doing this in a subsequent changeset.
