### PR TITLE
Makes #path portable by using File#expand_path

### DIFF
--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -11,7 +11,7 @@ class Exercism
     end
 
     def path
-      File.absolute_path(file)
+      File.expand_path(file)
     end
 
     def test?


### PR DESCRIPTION
I noticed that the latest [Travis CI build](https://travis-ci.org/kytrinyx/exercism/jobs/10349084) was broken by the use of `File.absolute_path`. This change makes the `Submission#path` implementation more portable to 1.8.7.
