### PR TITLE
Refactor submissions

### DIFF
--- a/bin/exercism
+++ b/bin/exercism
@@ -6,7 +6,7 @@ require 'cli'
 
 begin
   Exercism::CLI.start
-rescue Exception => e
+rescue StandardError => e
   puts
   puts "ERROR: Something went wrong. Exiting."
   puts e.message

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -74,20 +74,10 @@ class Exercism
         end
       end
 
-      begin
-        response = Exercism::Api.new(options[:host], Exercism.user).submit(submission.path)
-
-        body = JSON.parse(response.body)
-        if body["error"]
-          say body["error"]
-        else
-          say "Your assignment has been submitted."
-          url = "#{options[:host]}/#{Exercism.user.github_username}/#{body['language']}/#{body['exercise']}"
-          say "For feedback on your submission visit #{url}"
-        end
-      rescue Exception => e
-        puts "There was an issue with your submission."
-        puts e.message
+      monitored_request :submit, submission.path do |request, body|
+        say "Your assignment has been submitted."
+        url = "#{options[:host]}/#{Exercism.user.github_username}/#{body['language']}/#{body['exercise']}"
+        say "For feedback on your submission visit #{url}"
       end
     end
 
@@ -95,22 +85,11 @@ class Exercism
     method_option :host, :aliases => '-h', :default => 'http://exercism.io', :desc => 'the url of the exercism application'
     def unsubmit
       require 'exercism'
-      begin
-        api = Exercism::Api.new(options[:host], Exercism.user)
-        response = api.unsubmit
 
+      monitored_request :unsubmit do |request, body|
         if response.status == 204
           say "The last submission was successfully deleted."
-        else
-          body = JSON.parse(response.body)
-          if body["error"]
-            say body["error"]
-          end
         end
-
-      rescue Exception => e
-        puts "There was an issue with your request."
-        puts e.message
       end
     end
 
@@ -149,6 +128,7 @@ class Exercism
       ask("Your exercism.io API key:")
     end
 
+
     def project_dir
       default_dir = FileUtils.pwd
       say "What is your exercism exercises project path?"
@@ -173,5 +153,24 @@ class Exercism
       end
     end
 
+    def report_error(error)
+      abort error if error
+    end
+
+    def monitored_request(action, *args)
+      begin
+        request = api.public_send(action, *args)
+        body = JSON.parse(body)
+
+        if body["error"]
+          report_error
+        else
+          yield request, body
+        end
+      rescue Exception => e
+        puts "There was an issue with your request."
+        puts e.message
+      end
+    end
   end
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -159,7 +159,7 @@ class Exercism
 
     def monitored_request(action, *args)
       begin
-        request = api.public_send(action, *args)
+        request = api.send(action, *args)
         body = JSON.parse(body)
 
         if body["error"]

--- a/lib/cli/monitored_request.rb
+++ b/lib/cli/monitored_request.rb
@@ -1,0 +1,24 @@
+class Exercism
+  class CLI
+    class MonitoredRequest
+      attr_reader :api
+
+      def initialize(api)
+        @api = api
+      end
+
+      def request(action, *args)
+        begin
+          response = api.send(action, *args)
+          response_body = JSON.parse(response.body)
+
+          abort response_body["error"] if response_body["error"]
+
+          yield response, response_body
+        rescue Exception => e
+          abort "There was an issue with your request.\n#{e}"
+        end
+      end
+    end
+  end
+end

--- a/lib/exercism/api.rb
+++ b/lib/exercism/api.rb
@@ -32,23 +32,18 @@ class Exercism
     def submit(filename)
       path = File.join(filename)
       contents = File.read path
-      response = conn.post do |req|
-        req.url endpoint('user/assignments')
-        req.headers['Accept'] = 'application/json'
-        req.headers['Content-Type'] = 'application/json'
-        req.body = {:code =>  contents, :key => user.key, :path => path}.to_json
-      end
-      response
+
+      json_request(:post, 'user/assignments', {
+        key:  user.key,
+        code: contents,
+        path: path
+      })
     end
 
     def unsubmit
-      response = conn.delete do |req|
-        req.url endpoint('user/assignments')
-        req.headers['Accept'] = 'application/json'
-        req.headers['Content-Type'] = 'application/json'
-        req.params = {:key => user.key}
-      end
-      response
+      json_request(:delete, 'user/assignments', {
+        key: user.key
+      })
     end
 
     private
@@ -59,6 +54,17 @@ class Exercism
         req.params['key'] = user.key
       end
       save response.body
+    end
+
+    def json_request(verb, path, body)
+      response = conn.public_send(verb) do |request|
+        request.url endpoint(path)
+        request.headers['Accept'] = 'application/json'
+        request.headers['Content-Type'] = 'application/json'
+        request.body = body.to_json
+      end
+
+      response
     end
 
     def user_agent

--- a/lib/exercism/api.rb
+++ b/lib/exercism/api.rb
@@ -34,15 +34,15 @@ class Exercism
       contents = File.read path
 
       json_request(:post, 'user/assignments', {
-        key:  user.key,
-        code: contents,
-        path: path
+        :key  => user.key,
+        :code => contents,
+        :path => path
       })
     end
 
     def unsubmit
       json_request(:delete, 'user/assignments', {
-        key: user.key
+        :key => user.key
       })
     end
 
@@ -57,7 +57,7 @@ class Exercism
     end
 
     def json_request(verb, path, body)
-      response = conn.public_send(verb) do |request|
+      response = conn.send(verb) do |request|
         request.url endpoint(path)
         request.headers['Accept'] = 'application/json'
         request.headers['Content-Type'] = 'application/json'

--- a/test/cli/monitored_request_test.rb
+++ b/test/cli/monitored_request_test.rb
@@ -1,0 +1,53 @@
+require './test/test_helper'
+require 'cli/monitored_request'
+
+Struct.new('Response', :body)
+
+class MonitoredRequestTest < MiniTest::Unit::TestCase
+  def setup
+    setup_api
+    @monitored_request = Exercism::CLI::MonitoredRequest.new(@api)
+  end
+
+  def test_yield
+    @monitored_request.request :success_action do |response, body|
+      assert_equal 'Hi.', body["message"]
+    end
+  end
+
+  def test_response_errors
+    out, err = capture_subprocess_io do
+      pid = fork { @monitored_request.request :failure_action }
+      Process.wait pid
+    end
+
+    assert_match 'Error.', err
+  end
+
+  def test_handle_request_exceptions
+    out, err = capture_subprocess_io do
+      pid = fork { @monitored_request.request :exception_action }
+      Process.wait pid
+    end
+
+    assert_match 'There was an issue with your request.', err
+  end
+
+  private
+
+  def setup_api
+    @api = Minitest::Mock.new
+
+    def @api.failure_action
+      Struct::Response.new('{"error":"Error."}')
+    end
+
+    def @api.success_action
+      Struct::Response.new('{"message":"Hi."}')
+    end
+
+    def @api.exception_action
+      raise Exception
+    end
+  end
+end


### PR DESCRIPTION
Bare with me on this one. This is my attempt to refactor the API for JSON requests as well as simplify CLI for `submit` and `unsubmit`.

I was not entirely sure where to put everything so currently `monitored_request` is defined inside of CLI. To me that feel a bit odd, but I was hoping I could get some feedback on this.

Tests passed before I submitted this.
