### PR TITLE
Adding 'dir' command to display project root

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -125,6 +125,13 @@ class Exercism
     desc "stash [SUBCOMMAND]", "Stash or apply code that is in-progress"
     subcommand "stash", Stash
 
+    desc "dir", "Display the project path"
+    def dir
+      require 'exercism'
+
+      puts Exercism.config.project_dir
+    end
+
     private
 
     def username


### PR DESCRIPTION
Using Exercism on different machines I ofter forget in what directory I saved the exercises, so this would be somewhat helpfull to me. Don't know if many others have this 'problem'.

You can use it like this

```
cd `exercism dir`
```

or make an alias

```
alias e="cd `exercism dir`"
```

Making a `cd` command would have been a better sollution I think, but that is near impossible to make it work crossplatform (I read some Windows related stuff in the source) and even on UNIX I imagine it's not trivial.
